### PR TITLE
Mobile optimizations: Fix snapping speed and text positioning

### DIFF
--- a/script.js
+++ b/script.js
@@ -47,8 +47,9 @@ document.addEventListener("DOMContentLoaded", () => {
     const left = parseFloat(marker.style.left) || 0;
     const top = parseFloat(marker.style.top) || 0;
     
-    // Position the ball at the marker with a gentle transition
-    glowingBall.style.transition = 'left 0.6s ease-out, top 0.6s ease-out';
+    // Position the ball at the marker with a faster transition for mobile
+    const transitionSpeed = isMobile ? '0.4s' : '0.6s';
+    glowingBall.style.transition = `left ${transitionSpeed} ease-out, top ${transitionSpeed} ease-out`;
     glowingBall.style.left = `${left}px`;
     glowingBall.style.top = `${top}px`;
     
@@ -86,7 +87,7 @@ document.addEventListener("DOMContentLoaded", () => {
     
     // Re-enable transitions
     setTimeout(() => {
-      glowingBall.style.transition = 'left 0.6s ease-out, top 0.6s ease-out';
+      glowingBall.style.transition = isMobile ? 'left 0.4s ease-out, top 0.4s ease-out' : 'left 0.6s ease-out, top 0.6s ease-out';
       updateActiveSection(1);
     }, 50);
   }, 100);
@@ -125,7 +126,7 @@ document.addEventListener("DOMContentLoaded", () => {
       clearTimeout(scrollTimeout);
     }
     
-    // Set a new timeout
+    // Set a new timeout - FASTER on mobile
     scrollTimeout = setTimeout(() => {
       if (isScrolling) return;
       
@@ -136,7 +137,7 @@ document.addEventListener("DOMContentLoaded", () => {
       if (mostVisibleSection !== activeSection) {
         updateActiveSection(mostVisibleSection);
       }
-    }, isMobile ? 50 : 100); // Shorter timeout for mobile
+    }, isMobile ? 30 : 100); // Reduced timeout for more responsive mobile experience
   }, { passive: true });
   
   // Enhanced touch handling for mobile
@@ -163,7 +164,7 @@ document.addEventListener("DOMContentLoaded", () => {
       setTimeout(() => {
         const mostVisibleSection = getMostVisibleSection();
         updateActiveSection(mostVisibleSection);
-      }, 100);
+      }, 50); // Reduced from 100 to 50 for faster mobile response
     }
   }, { passive: true });
   
@@ -194,7 +195,8 @@ document.addEventListener("DOMContentLoaded", () => {
     
     // Re-enable transitions after a short delay
     setTimeout(() => {
-      glowingBall.style.transition = 'left 0.6s ease-out, top 0.6s ease-out';
+      const transitionSpeed = isNowMobile ? '0.4s' : '0.6s';
+      glowingBall.style.transition = `left ${transitionSpeed} ease-out, top ${transitionSpeed} ease-out`;
     }, 50);
   });
   
@@ -257,10 +259,10 @@ document.addEventListener("DOMContentLoaded", () => {
         });
       }
       
-      // Reset scrolling flag after animation completes
+      // Reset scrolling flag after animation completes - faster on mobile
       setTimeout(() => {
         isScrolling = false;
-      }, 600);
+      }, isMobile ? 400 : 600); // Reduced timeout for mobile
     }
   });
 });

--- a/styles.css
+++ b/styles.css
@@ -314,6 +314,8 @@ body {
     height: auto;
     overflow-y: auto;
     padding-bottom: 60px; /* Add padding at the bottom for better scrolling */
+    scroll-behavior: smooth;
+    scroll-snap-type: y proximity; /* Changed from mandatory to proximity for better experience */
   }
   
   /* Make each step section taller to prevent skipping */
@@ -323,9 +325,11 @@ body {
     padding: 2rem 1rem;
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: flex-end; /* Changed from center to flex-end to align content to bottom */
     position: relative;
     scroll-margin-top: 40vh; /* Offset for sticky header */
+    scroll-snap-align: end; /* Changed from start to end to snap to bottom */
+    scroll-snap-stop: always; /* Force stopping at each section */
   }
   
   /* Ensure the step content is always visible */
@@ -334,6 +338,7 @@ body {
     opacity: 1 !important; /* Always visible */
     transform: none !important; /* No transform */
     transition: none !important; /* No transitions */
+    padding-bottom: 2rem; /* More padding to prevent content being cut off */
   }
   
   .sign-up-button {
@@ -394,17 +399,6 @@ body {
     height: 14px;
     box-shadow: 0 0 20px 6px rgba(255, 107, 0, 0.8); /* Enhanced glow */
   }
-  
-  /* Improve scroll snapping */
-  .steps-container {
-    scroll-behavior: smooth;
-    scroll-snap-type: y proximity; /* Changed from mandatory to proximity */
-  }
-  
-  .step-section {
-    scroll-snap-align: start;
-    scroll-snap-stop: always; /* Force stopping at each section */
-  }
 }
 
 /* Adjust for smaller mobile screens */
@@ -420,7 +414,9 @@ body {
   
   .step-section {
     min-height: 65vh;
-    padding: 1.5rem 0.75rem;
+    padding: 1.5rem 0.75rem 3rem 0.75rem; /* Added bottom padding */
+    justify-content: flex-end; /* Ensure text content aligns to bottom */
+    scroll-snap-align: end; /* Force snap to bottom */
   }
   
   /* Adjust for smaller phones */
@@ -457,6 +453,7 @@ body {
   
   .step-content {
     max-width: 100%;
+    margin-bottom: 1rem; /* Add space at bottom */
   }
   
   .step-content h2 {


### PR DESCRIPTION
## Changes
- Speed up the snapping transition on mobile devices (0.4s instead of 0.6s)
- Improve scroll handling with shorter timeouts for more responsive mobile experience
- Fix text content position to snap to the bottom only (previously snapped to both top and bottom)
- Change scroll-snap-align to "end" instead of "start" on mobile to keep content visible
- Add bottom padding to ensure text isn't cut off
- Use proximity snapping for smoother scrolling experience

## Testing
Tested on mobile devices to ensure proper text positioning and improved snapping performance. The changes specifically address:
1. The text positioning issue shown in the screenshot where content was cut off
2. The slow snapping speed, which is now 33% faster on mobile
3. Improved scroll response time by reducing timeouts by up to 40%

These changes maintain the existing desktop experience while optimizing for mobile users.