### PR TITLE
Fix mobile spacing issues

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -348,8 +348,8 @@ body {
     position: sticky;
     top: 0;
     width: 100%;
-    height: 40vh; /* Reduced height to show more content */
-    min-height: 250px;
+    height: 35vh; /* Reduced height to show more content */
+    min-height: 220px; /* Reduced min-height to save space */
     z-index: 10;
     padding: 1rem;
     background-color: var(--background-color);
@@ -375,8 +375,8 @@ body {
     transform: none !important; /* No transform */
     transition: none !important; /* No transitions */
     padding-bottom: 2rem; /* More padding to prevent content being cut off */
-    margin-top: 15vh; /* Increased top margin to prevent overlap with staircase */
-    padding-top: 2vh; /* Additional top padding */
+    margin-top: 5vh; /* Reduced top margin to make content immediately visible */
+    padding-top: 0; /* Removed additional top padding */
   }
   
   .sign-up-button {
@@ -439,7 +439,7 @@ body {
   
   /* Position all sections for iOS to avoid text overlap with stairs */
   .step-section {
-    padding-top: 45vh; /* Reduced top padding to make content more visible */
+    padding-top: 30vh; /* Reduced top padding to make content immediately visible */
     justify-content: flex-start; /* Align content to start (top) after padding */
     min-height: 100vh; /* Full viewport height */
     padding-bottom: 8rem; /* More bottom padding */
@@ -450,8 +450,8 @@ body {
 /* Adjust for smaller mobile screens */
 @media (max-width: 480px) {
   .penrose-container {
-    height: 38vh; /* Reduced height to show more content */
-    min-height: 220px; /* Reduced min-height */
+    height: 35vh; /* Reduced height to show more content */
+    min-height: 200px; /* Reduced min-height */
     padding: 0.5rem;
     justify-content: flex-start;
     padding-top: 1rem; /* Less top padding */
@@ -460,7 +460,7 @@ body {
   
   .step-section {
     min-height: 100vh;
-    padding: 40vh 0.75rem 8rem 0.75rem; /* Reduced top padding to show content better */
+    padding: 25vh 0.75rem 8rem 0.75rem; /* Further reduced top padding for better content visibility */
     justify-content: flex-start; /* Align to top of available area after padding */
     scroll-snap-align: start; /* Snap to start */
     scroll-snap-stop: normal; /* Make scrolling less rigid for easier navigation */


### PR DESCRIPTION
This PR fixes the mobile spacing issues in the mobile-final-fixes branch. The main problems were:

1. The top margin on `.step-content` was set too high (15vh), preventing the step content from being visible in the initial viewport.
2. The top padding on `.step-section` for mobile devices was too large, pushing content out of view.

Changes made:
- Reduced top margin on `.step-content` from 15vh to 5vh
- Reduced top padding on `.step-section` from 45vh to 30vh for mobile
- Further reduced top padding to 25vh for smaller mobile screens
- Reduced heights for `.penrose-container` to allow more space for content
- Removed unnecessary top padding
- Optimized vertical spacing throughout the mobile view

These changes ensure the step content is immediately visible when navigating on mobile, improving the user experience while maintaining the visual design.